### PR TITLE
fix(android): explicitly disable cleartext traffic in AndroidManifest…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <application
         android:allowBackup="true"
+        android:usesCleartextTraffic="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
….xml

By default, older Android versions allow cleartext network traffic if not explicitly disabled. This commit adds android:usesCleartextTraffic="false" to the <application> tag in AndroidManifest.xml to address the security hotspot reported by SonarCloud, ensuring that unencrypted traffic is disabled on all supported devices.