### PR TITLE
fix(android): downgrade AGP version in version catalog in libs.versio…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.0"
+agp = "8.4.0"
 kotlin = "2.0.21"
 coreKtx = "1.15.0"
 junit = "4.13.2"


### PR DESCRIPTION
…ns.toml

Updated [versions] agp value from "8.9.0" to "8.4.0" in libs.versions.toml to ensure compatibility with our current Android Studio environment, which supports AGP up to 8.4.0. This resolves the AGP incompatibility error during project sync.