### PR TITLE
task(ci): add unit test execution step to GitHub Actions CI pipeline for task #17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,7 @@ jobs:
 
       - name: Build Debug
         run: ./gradlew assembleDebug
+
+      - name: Run Unit Tests
+        run: ./gradlew test
+


### PR DESCRIPTION
Added a step to run unit tests using `./gradlew test` in the CI pipeline.
This step ensures that tests are executed automatically during each build.
